### PR TITLE
CI: added digest (index when possible) for external images used in gh actions

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -335,13 +335,13 @@ jobs:
       matrix:
         include:
           - backend: gsqlite3
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
           - backend: gmysql
-            image: mysql:5
+            image: mysql@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb # mysql:5.7.44
           - backend: gpgsql
-            image: postgres:14
+            image: postgres@sha256:bbcaba1d74865ee6d6318b5e297d0df73d1f6b6d995cd892b60a2cf1440b716a # postgres:14.18
           - backend: lmdb
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
       fail-fast: false
     services:
       database:
@@ -407,76 +407,76 @@ jobs:
       matrix:
         include:
           - backend: remote
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: gmysql
-            image: mysql:5
+            image: mysql@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb # mysql:5.7.44
             env:
               MYSQL_ALLOW_EMPTY_PASSWORD: 1
             ports:
             - 3306:3306
           - backend: gmysql
-            image: mariadb:10
+            image: mariadb@sha256:34adebbac117c8ce649040e009f520fb79e577c68cc4e57debdf91befa53907f # mariadb:10.11.13
             env:
               MYSQL_ALLOW_EMPTY_PASSWORD: 1
             ports:
             - 3306:3306
           - backend: gpgsql
-            image: postgres:14
+            image: postgres@sha256:bbcaba1d74865ee6d6318b5e297d0df73d1f6b6d995cd892b60a2cf1440b716a # postgres:14.18
             env:
               POSTGRES_USER: runner
               POSTGRES_HOST_AUTH_METHOD: trust
             ports:
             - 5432:5432
           - backend: gsqlite3  # this also runs regression-tests.nobackend and pdnsutil test-algorithms
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: lmdb
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: bind
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: geoip
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: lua2
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: tinydns
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: authpy
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: godbc_sqlite3
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
           - backend: godbc_mssql
-            image: mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04
+            image: mcr.microsoft.com/mssql/server@sha256:b94071acd4612bfe60a73e265097c2b6388d14d9d493db8f37cf4479a4337480 # mcr.microsoft.com/mssql/server:2022-CU12-ubuntu-22.04
             env:
               ACCEPT_EULA: Y
               SA_PASSWORD: 'SAsa12%%-not-a-secret-password'
             ports:
               - 1433:1433
           - backend: ldap
-            image: powerdns/ldap-regress:1.2.4-1
+            image: powerdns/ldap-regress@sha256:1cc8511d0eb28ac7169042e9b8ae88f9ed5f93b8ac3a550755c56eaaa153680e # powerdns/ldap-regress:1.2.4-1
             env:
               LDAP_LOG_LEVEL: 0
               CONTAINER_LOG_LEVEL: 4
             ports:
               - 389:389
           - backend: geoip_mmdb
-            image: coscale/docker-sleep
+            image: coscale/docker-sleep@sha256:7ac94378c23c68b47c623dee4b3ac694ed7201543df3feed668e487ef1102fc5
             env: {}
             ports: []
       fail-fast: false

--- a/.github/workflows/misc-dailies.yml
+++ b/.github/workflows/misc-dailies.yml
@@ -105,7 +105,7 @@ jobs:
     needs: list-pip-requirement-files
     services:
       database:
-        image: epicwink/proxpi
+        image: epicwink/proxpi@sha256:a219ea0ef4f5b272eaf18bc5a5d00220c5aa07debb434d36161550862768aa93
         ports:
           - 5000:5000
         options: >-


### PR DESCRIPTION
@rgacogne 

I checked the images we use in our CI and this PR adds the digest for the external ones.

For the image we use as a "runner", we could also add the digest of the Python image we use at build time.

If this PR is not useful please ignore it :)
 